### PR TITLE
Fix file permission check in configure()

### DIFF
--- a/lib/fluent/plugin/in_sigdump.rb
+++ b/lib/fluent/plugin/in_sigdump.rb
@@ -36,7 +36,7 @@ module Fluent
         super
 
         @dir_permission = system_config.dir_permission || Fluent::DEFAULT_DIR_PERMISSION
-        unless Fluent::FileUtil.writable_p?(@dir_path)
+        unless Fluent::FileUtil.writable_p?(get_output_path())
           raise Fluent::ConfigError, "'dir_path' doesn't have enough permission.: #{@dir_path}"
         end
       end
@@ -62,14 +62,17 @@ module Fluent
         FileUtils.mkdir_p(@dir_path, mode: @dir_permission)
       end
 
-      def dump
+      def get_output_path
         time_stamp = Time.at(Fluent::EventTime.now).strftime("%Y%m%d_%H%M%S")
         filename = "sigdump_#{time_stamp}.txt"
-        ouput_path = "#{@dir_path}/#{filename}"
+        return "#{@dir_path}/#{filename}"
+      end
 
-        Sigdump.dump(ouput_path)
+      def dump
+        output_path = get_output_path()
+        Sigdump.dump(output_path)
 
-        $log.debug("Output sigdump file: #{ouput_path}")
+        $log.debug("Output sigdump file: #{output_path}")
       end
     end
   end


### PR DESCRIPTION
This check fails when there is an existing directory on `dir_path`.
For example:

```bash
    $ stat /tmp/ --format %F
    directory
    $ fluentd -c sigdump.conf
    ...
    2022-02-20 15:39:46 +0900 [error]: config error file="sigdump.conf"
    error_class=Fluent::ConfigError error="'dir_path' doesn't have
    enough permission.: /tmp"
```

This is because `FileUtils.writiable_p()` check if the ruby process
can write a "file" on that path, so it naturally returns false if
the target path is occupied with a directory.

We can avoid this issue by calling this function with an actual file
path (not the base directory path) that we want to use. Fix it.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>