### PR TITLE
Fix "uninitialized constant Fluent::Plugin::Input" error

### DIFF
--- a/lib/fluent/plugin/in_sigdump.rb
+++ b/lib/fluent/plugin/in_sigdump.rb
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'fluent/plugin/input'
 require "sigdump"
 require "fileutils"
 require 'fluent/plugin/file_util'


### PR DESCRIPTION
Suppose we have a simple configuration like this:

    <source>
      @type sigdump
    </source>
    <match **>
      @type stdout
    </match>

Currently running Flunetd with this configuration results in the
following error:

    in_sigdump.rb:23:in `<module:Plugin>': uninitialized constant
    Fluent::Plugin::Input (NameError)

Fix it by adding an explicit requirement for 'fluent/plugin/input'.

Signed-off-by: Fujimoto Seiji <fujimoto@ceptord.net>